### PR TITLE
Update publishing setup for typesafe-ivy-releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,11 +14,10 @@ scalaVersion := scala212Version
 
 crossScalaVersions := Seq(scala212Version, scala211Version, scala210Version)
 
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
-
-val typesafeIvyReleases = Resolver.url("typesafe-ivy-private-releases", new URL("http://private-repo.typesafe.com/typesafe/ivy-releases/"))(Resolver.ivyStylePatterns)
-
-publishTo := Some(typesafeIvyReleases)
+bintrayOrganization := Some("typesafe")
+bintrayRepository := "ivy-releases"
+bintrayPackage := "emoji"
+bintrayReleaseOnPublish := false
 
 publishMavenStyle := false
 

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
I've created a package in the repo and successfully staged a 1.1.0 release of this build at https://bintray.com/typesafe/ivy-releases/emoji in case you want to publish it (without merging #4 first).